### PR TITLE
fix warnings during build

### DIFF
--- a/skript/Makefile
+++ b/skript/Makefile
@@ -32,7 +32,8 @@ images-subdir:
 	cd images; make
 
 clean:
-	rm -f skript.dvi skript.pdf
+	rm -f *.synctex.gz *.aux *.idx *.ilg *.ind *.log *.out *.toc *.dvi \
+		skript.pdf checklist.pdf
 
 checklist.pdf:	checklist.tex
 	pdflatex checklist.tex

--- a/skript/applications/sniping.tex
+++ b/skript/applications/sniping.tex
@@ -50,7 +50,6 @@ ein $m^2$-dimensionaler Vektor $U$.
 \begin{figure}
 \[
 \Delta_4=
-\small
 \left(\begin{array}{ccccccccccccccccccccccccc}
    2& -1&   &   &   & -1&   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   \\
   -1&  3& -1&   &   &   & -1&   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   \\
@@ -76,7 +75,7 @@ ein $m^2$-dimensionaler Vektor $U$.
     &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   & -1&   &   &   & -1&  3& -1&   &   \\
     &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   & -1&   &   &   & -1&  3& -1&   \\
     &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   & -1&   &   &   & -1&  3& -1\\
-    &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   & -1&  2
+    &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   &   & -1&   &   &   & -1&  2
 \end{array}\right)
 \]
 \caption{Laplace-Operator des Widerstandsgitters\label{delta4}}

--- a/skript/geometrie.tex
+++ b/skript/geometrie.tex
@@ -130,7 +130,7 @@ Algebra in den Mengen $\mathbb R^n$ zu entwickeln und m"oglichst viel
 der bekannten Vektorgeometrischen Vorstellungen in diese Sprache
 zu "ubertragen.
 
-\section{Vektorr"aume $\mathbb R^n$ und Unterr"aume}
+\section{Vektorr"aume \texorpdfstring{$\mathbb R^n$}{R hoch n} und Unterr"aume}
 \index{Vektorraum@Vektorraum $\mathbb R^n$}
 Die Menge $V$ der $n$-dimensionalen Spaltenvektoren bildet was man
 einen Vektorraum nennt: Spaltenvektoren k"onnen addiert und mit

--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -30,6 +30,7 @@
 \setlength{\unitlength}{1pt}
 \usepackage{color}
 \makeindex
+\setlength{\headheight}{15pt}
 \begin{document}
 \pagestyle{fancy}
 \lhead{Lineare Algebra}
@@ -55,7 +56,6 @@ Hochschule f"ur Technik, Rapperswil, 2009-2015
 \end{center}
 \end{titlepage}
 \hypersetup{
-    colorlinks=true,
     linktoc=all,
     linkcolor=blue
 }

--- a/skript/vektorgeometrie.tex
+++ b/skript/vektorgeometrie.tex
@@ -1580,7 +1580,7 @@ entgegegengesetzte Richtung:
 -
 (\vec v\cdot\vec n)\vec n
 =\vec v-2(\vec v\cdot\vec n)\vec n.
-\label{spiegelung}
+\label{equation:spiegelung}
 \end{equation}
 
 \begin{beispiel}
@@ -1605,7 +1605,7 @@ Komponenten zerlegt werden:
 \quad
 \vec a_{\|}=\begin{pmatrix} -1\\0\\1 \end{pmatrix}.
 \]
-Nach Formel (\ref{spiegelung}) ist
+Nach Formel (\ref{equation:spiegelung}) ist
 \[
 \vec a'=\vec a_{\|}-\vec a_{\perp}
 =


### PR DESCRIPTION
- pdfstring warning fix
- headheight warning fix
- multiple references fix
- updated make clean to erase more files generated during build
-> skript needs to be build twice to resolve reference warnings!
- \small not valid in math mode -> removed

Missing files:
- applications/lapackaf.c
- applications/lapackab.c
- applications/laspacka.c